### PR TITLE
add command handler for fake kernel

### DIFF
--- a/src/Extension.Tests/Utilities/ProgressiveLearningTestBase.cs
+++ b/src/Extension.Tests/Utilities/ProgressiveLearningTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.DotNet.Interactive;
+using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
 using System;
 using System.Collections.Generic;
@@ -20,10 +21,12 @@ namespace Extension.Tests.Utilities
 
         protected async Task<CompositeKernel> CreateKernel(LessonMode mode, HttpClient httpClient = null)
         {
+            var vscodeKernel = new FakeKernel("vscode");
+            vscodeKernel.RegisterCommandHandler<SendEditableCode>((_, _) => Task.CompletedTask);
             var kernel = new CompositeKernel
             {
                 new CSharpKernel().UseNugetDirective().UseKernelHelpers(),
-                new FakeKernel("vscode")
+                vscodeKernel
             };
 
             Lesson.Mode = mode;


### PR DESCRIPTION
The goal of having the fake kernel was to stop "CommandFailed NoSuitableKernel for SendEditableCode" errors from obfuscating KernelEvents in tests. Just having the FakeKernel is not enough, we also need a CommandHandler for SendEditableCode.